### PR TITLE
Add 2.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tabula-py" %}
-{% set version = "2.2.0" %}
+{% set version = "2.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bb4b8bb37616b4baf74deed7114e75bfcf0faa41bc55d2aa04834f56a98ab838
+  sha256: 9da61aa5d4256f79e7fa64d1fb09956d4c104d1a0116566c43bf9f612f37c149
 
 build:
-  number: 1
-  skip: True  # [py2k]
+  number: 0
+  skip: True  # [py<37]
+  # openjdk >=8 isn't available on ppc64le
+  skip: True  # [ppc64le]
   script:
     - python -m pip install --no-deps --ignore-installed --use-feature=in-tree-build .
 
@@ -19,22 +21,23 @@ requirements:
   host:
     - python
     - pip
-    - flake8
     - setuptools
     - setuptools_scm
   run:
     - python
-    - pandas
-    - numpy
-    - requests
-    - distro  # [linux]
-    - openjdk
-    - setuptools
-    - setuptools_scm
+    - pandas >=0.25.3
+    - {{ pin_compatible('numpy') }}
+    - distro
+    - openjdk >=8
 
 test:
   imports:
     - tabula
+  requires:
+    - pip
+  commands:
+    - python -c "import tabula; tabula.environment_info()"
+    - pip check 
 
 about:
   home: https://github.com/chezou/tabula-py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,8 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
-  # openjdk >=8 isn't available on ppc64le
-  skip: True  # [ppc64le]
+  # openjdk >=8 isn't available on ppc64le, s390x, and arm64
+  skip: True  # [ppc64le or s390x or arm64]
   script:
     - python -m pip install --no-deps --ignore-installed --use-feature=in-tree-build .
 


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/chezou/tabula-py/issues
Github releases:  https://github.com/chezou/tabula-py/releases
Upstream license:  License file:  https://github.com/chezou/tabula-py/blob/master/LICENSE
Upstream setup file: https://github.com/chezou/tabula-py/blob/v2.3.0/setup.cfg

Actions:
1. Skip building on `ppc64le`, `s390x` and `arm64`
2. Fix run dependencies
3. Add `pip` in test/requires
4. Add `pip check` and `python -c "import tabula; tabula.environment_info()"` in test/commands

Result:
- all-succeeded
