### PR TITLE
2.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,6 @@ requirements:
     - openjdk >=8
 
 test:
-  imports:
-    - tabula
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - pip
     - setuptools
     - setuptools_scm
+    - wheel
   run:
     - python
     - pandas >=0.25.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   run:
     - python
     - pandas >=0.25.3
-    - {{ pin_compatible('numpy') }}
+    - numpy
     - distro
     - openjdk >=8
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   # openjdk >=8 isn't available on ppc64le, s390x, and arm64
   skip: True  # [ppc64le or s390x or arm64]
   script:
-    - python -m pip install --no-deps --ignore-installed --use-feature=in-tree-build .
+    - python -m pip install --no-deps --ignore-installed .
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tabula-py" %}
-{% set version = "2.3.0" %}
+{% set version = "2.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9da61aa5d4256f79e7fa64d1fb09956d4c104d1a0116566c43bf9f612f37c149
+  sha256: b10b83d15e7209fcf65c64dee064bdb2d50b06a7e4e28fc9974b92c9ef14c5cc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   skip: True  # [py<37]
   # openjdk >=8 isn't available on ppc64le, s390x, and arm64
-  skip: True  # [ppc64le or s390x or arm64]
+  skip: True  # [ppc64le or s390x]
   script:
     - python -m pip install --no-deps --ignore-installed .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
-  # openjdk >=8 isn't available on ppc64le, s390x, and arm64
+  # openjdk >=8 isn't available on ppc64le, s390x
   skip: True  # [ppc64le or s390x]
   script:
     - python -m pip install --no-deps --ignore-installed .


### PR DESCRIPTION
# tabula-py 2.6.0

upstream: https://github.com/chezou/tabula-py/tree/v2.6.0
release notes: https://github.com/chezou/tabula-py/releases/tag/v2.6.0
`setup.cfg`: https://github.com/chezou/tabula-py/blob/v2.6.0/setup.cfg#L30


## Changes 
- Bump version and SHA
- Add back osx arm now that JDK is available
- Fix for tests
- Add missing dependency

## Notes
- This version adds python 3.11 support